### PR TITLE
Updated player saving, UPDATE_SKILLS and other minor fixes.

### DIFF
--- a/src/client/MapleCharacter.java
+++ b/src/client/MapleCharacter.java
@@ -6809,6 +6809,7 @@ public class MapleCharacter extends AnimatedMapleMapObject implements Serializab
         PlayerBuffStorage.addBuffsToStorage(getId(), getAllBuffs());
         PlayerBuffStorage.addCooldownsToStorage(getId(), getCooldowns());
         PlayerBuffStorage.addDiseaseToStorage(getId(), getAllDiseases());
+        getClient().getSession().write(CWvsContext.updateSkills(getSkills(), false));
         World.ChannelChange_Data(new CharacterTransfer(this), getId(), channel);
         ch.removePlayer(this);
         client.updateLoginState(MapleClient.CHANGE_CHANNEL, client.getSessionIPAddress());

--- a/src/handling/MapleServerHandler.java
+++ b/src/handling/MapleServerHandler.java
@@ -141,6 +141,7 @@ public class MapleServerHandler extends IoHandlerAdapter {
             }
             
             session.close();
+            client.disconnect(true, false);
             session.removeAttribute(MapleClient.CLIENT_KEY);
         }
         super.sessionClosed(session);
@@ -166,7 +167,7 @@ public class MapleServerHandler extends IoHandlerAdapter {
     	
     	String bytes = lea.toString();
     	
-    	// System.out.println("[Sent] (" + opcode + ") " + bytes);
+    	 System.out.println("[Sent] (" + opcode + ") " + bytes);
     }
 
     @Override

--- a/src/handling/SendPacketOpcode.java
+++ b/src/handling/SendPacketOpcode.java
@@ -32,12 +32,12 @@ public enum SendPacketOpcode {
     // CWvsContext::OnPacket (this has been updated.)
     INVENTORY_OPERATION(0x47),
     INVENTORY_GROW(0x48),
-    UPDATE_STATS(0x49),
+    UPDATE_STATS(0x49), // OnStatUpdate
     GIVE_BUFF(0x4A),
     CANCEL_BUFF(0x4B),
     TEMP_STATS(0x4C),
     TEMP_STATS_RESET(0x4D),
-    UPDATE_SKILLS(0x4E),
+    UPDATE_SKILLS(0x4E), // OnChangeSkillRecordResult
     UPDATE_STOLEN_SKILLS(0x4F),
     TARGET_SKILL(0x56),
     FAME_RESPONSE(0x58),

--- a/src/handling/handlers/login/ClientErrorHandler.java
+++ b/src/handling/handlers/login/ClientErrorHandler.java
@@ -9,6 +9,7 @@ public class ClientErrorHandler {
 	
 	@PacketHandler(opcode = RecvPacketOpcode.CLIENT_ERROR)
 	public static void handle(MapleClient c, LittleEndianAccessor lea) {
+        c.disconnect(true, false);
 		if (lea.available() < 8) {
             System.out.println(lea.toString());
             return;

--- a/src/handling/handlers/login/PlayerLoggedInHandler.java
+++ b/src/handling/handlers/login/PlayerLoggedInHandler.java
@@ -114,8 +114,7 @@ public class PlayerLoggedInHandler {
 		
 		// PlayersHandler.calcHyperSkillPointCount(c);
 		// c.getSession().write(CSPacket.enableCSUse());
-		// c.getSession().write(CWvsContext.updateSkills(c.getPlayer().getSkills(),
-		// false));//skill to 0 "fix"
+		c.getSession().write(CWvsContext.updateSkills(c.getPlayer().getSkills(), false));//skill to 0 "fix"
 		// player.getStolenSkills();
 		// c.getSession().write(JobPacket.addStolenSkill());
 

--- a/src/server/commands/PlayerCommand.java
+++ b/src/server/commands/PlayerCommand.java
@@ -112,7 +112,7 @@ public class PlayerCommand {
 	public abstract static class DistributeStatCommands extends CommandExecute {
 
 		protected MapleStat stat = null;
-		private static final int statLim = 999;
+		private static final int statLim = 500000;
 		private static final int hpMpLim = 500000;
 
 		private void setStat(MapleCharacter player, int current, int amount) {


### PR DESCRIPTION
Player data now gets correctly saved after logging out or crashing. Should also fix not being flagged as logged out after logging out. UPDATE_SKILLS is now correctly called as well, ensuring skills are saved upon dcing/ccing. After using !job, you still 38, however. I tried fixing this, added some stuff I saw in IDA, but no luck yet.
