### PR TITLE
Two changes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <version>1.75.1</version>
+  <version>1.76.2</version>
   <name>Mushy</name>
   <build>
     <directory>${project.basedir}/bin</directory>

--- a/src/handling/handlers/login/CharacterWithoutSecondPassword.java
+++ b/src/handling/handlers/login/CharacterWithoutSecondPassword.java
@@ -28,7 +28,7 @@ public class CharacterWithoutSecondPassword {
             c.getSession().close();
             return;
         }
-        lea.skip(1); //prevents the ArrayIndexArrayOutOfBounds exception. Don't know what it is yet.
+        //lea.skip(1); //prevents the ArrayIndexArrayOutOfBounds exception. Don't know what it is yet.
         c.updateMacs(lea.readMapleAsciiString());
         
         lea.readMapleAsciiString();


### PR DESCRIPTION
Removed Lea.skip(1) that "prevents" the ArrayIndexArrayOutOfBounds, when it actually causes it. 

Updated Pom.xml from 1.75.1 to 1.76.2 to reflect the updated version,
