### PR TITLE
Fix for selling items.

### DIFF
--- a/src/server/shops/MapleShop.java
+++ b/src/server/shops/MapleShop.java
@@ -222,23 +222,12 @@ public class MapleShop {
             }
             MapleInventoryManipulator.removeFromSlot(c, type, (short) slot, quantity, false);
             double price;
-            if (!"".equals(item.getGMLog())) {
-                if (item.getGMLog().toUpperCase().startsWith("DROP")) {
-                    if ((GameConstants.isThrowingStar(item.getItemId())) || (GameConstants.isBullet(item.getItemId()))) {
-                        price = ii.getWholePrice(item.getItemId()) / ii.getSlotMax(item.getItemId());
-                    } else {
-                        price = ii.getPrice(item.getItemId());
-                    }
-                } else {
-                    price = 1.0D;
-                }
-            } else {
-                if ((GameConstants.isThrowingStar(item.getItemId())) || (GameConstants.isBullet(item.getItemId()))) {
+            
+            if ((GameConstants.isThrowingStar(item.getItemId())) || (GameConstants.isBullet(item.getItemId()))) {
                     price = ii.getWholePrice(item.getItemId()) / ii.getSlotMax(item.getItemId());
                 } else {
                     price = ii.getPrice(item.getItemId());
                 }
-            }
 
             int recvMesos = (int) Math.max(Math.ceil(price * quantity), 0.0D);
             if ((price != -1.0D) && (recvMesos > 0)) {


### PR DESCRIPTION
The check was failing, causing all items to be sold for 1 Meso. Removed the check and I was able to sell items for the normal price.

Have not tested throwing stars or bullets, just regular items.
For some reason MapleStory hard crashes when purchasing items, will look into it further.
